### PR TITLE
Add Pack and Unpack

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: ["1.20.11", "1.21.4"]
+        go-version: ["1.21.9", "1.22.2"]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ if opt.IsPresent() {
 	v := opt.Unwrap()
 	DoSomething(v)
 }
+
+// You can also use Unpack to check presence and get the value at once.
+if v, ok := opt.Unpack(); ok {
+	DoSomething(v)
+}
 ```
 
 ## Interoperability

--- a/options.go
+++ b/options.go
@@ -41,15 +41,21 @@ func FromPointer[T any](ptr *T) Option[T] {
 	}
 }
 
-// FromTuple creates Option[T] from a tuple of (T, bool).
+// Pack creates Option[T] from (T, bool).
 // If the bool is true, a new Option[T] with the given value is returned.
 // Otherwise, None is returned.
-func FromTuple[T any](value T, present bool) Option[T] {
+func Pack[T any](value T, present bool) Option[T] {
 	if present {
 		return New(value)
 	} else {
 		return None[T]()
 	}
+}
+
+// FromTuple is an alias of [Pack].
+// Newer code should use [Pack] instead of this function.
+func FromTuple[T any](value T, present bool) Option[T] {
+	return Pack(value, present)
 }
 
 // IsPresent returns true if the option has a value.
@@ -97,6 +103,13 @@ func (o *Option[T]) Pointer() *T {
 	} else {
 		return nil
 	}
+}
+
+// Unpack returns (value, present).
+// If the option is None, value is always zero.
+// This function is useful when you want to check the presence of the value and get it at once.
+func (o *Option[T]) Unpack() (T, bool) {
+	return o.value, o.present
 }
 
 // Map returns a new option by applying the given function to the value of the option.

--- a/options.go
+++ b/options.go
@@ -53,7 +53,8 @@ func Pack[T any](value T, present bool) Option[T] {
 }
 
 // FromTuple is an alias of [Pack].
-// Newer code should use [Pack] instead of this function.
+//
+// Deprecated: newer code should use [Pack] instead of this function.
 func FromTuple[T any](value T, present bool) Option[T] {
 	return Pack(value, present)
 }

--- a/options_test.go
+++ b/options_test.go
@@ -52,11 +52,11 @@ func toSQLValue[T any](t *testing.T, opt options.Option[T]) driver.Value {
 	return value
 }
 
-func ExampleFromTuple() {
-	some := options.FromTuple(42, true)
+func ExamplePack() {
+	some := options.Pack(42, true)
 	fmt.Println(some.GoString())
 
-	none := options.FromTuple[int](0, false)
+	none := options.Pack[int](0, false)
 	fmt.Println(none.GoString())
 
 	// Output:
@@ -93,6 +93,21 @@ func ExampleOption_UnwrapOrZero() {
 	// Output:
 	// 42
 	// 0
+}
+
+func ExampleOption_Unpack() {
+	some := options.New("hello")
+	if s, ok := some.Unpack(); ok {
+		fmt.Println(s)
+	}
+
+	none := options.None[string]()
+	if s, ok := none.Unpack(); ok {
+		fmt.Println(s)
+	}
+
+	// Output:
+	// hello
 }
 
 func ExampleMap() {


### PR DESCRIPTION
This PR adds `Pack` and `Unpack` to `Option[T]`.
These functions convert between (value, present) and Option[T].

Unpack is useful in the following frequently encountered situations:

```go
// We do not need to call IsPresent and Unwrap separately.
if value, ok := optValue.Unpack(); ok {
    doSomething(value)
}
```

The name Unpack is taken from `Tuple.Unpack` in `lo`, and the name Pack comes from the fact that it is the reverse operation of Unpack.

There is already a function defined as `FromTuple` that performs the same operation as Pack. I made it an alias of Pack.