### PR TITLE
If T is Valuer, then Option[T] should be Valuer

### DIFF
--- a/options.go
+++ b/options.go
@@ -147,6 +147,9 @@ func (o *Option[T]) UnmarshalJSON(bytes []byte) error {
 // See http://jmoiron.net/blog/built-in-interfaces
 func (o Option[T]) Value() (driver.Value, error) {
 	if o.present {
+		if valuer, ok := any(&o.value).(driver.Valuer); ok {
+			return valuer.Value()
+		}
 		return o.value, nil
 	} else {
 		return nil, nil

--- a/options_test.go
+++ b/options_test.go
@@ -187,6 +187,21 @@ func TestJSONUnmarshal(t *testing.T) {
 	assertDeepEqual(t, *opt6, options.New(map[string]int{"foo": 1, "bar": 2}))
 }
 
+type wrappedString string
+
+func (ws *wrappedString) Scan(src any) error {
+	s, ok := src.(string)
+	if !ok {
+		return fmt.Errorf("wrappedString.Scan: unexpected type %T", src)
+	}
+	*ws = wrappedString(s)
+	return nil
+}
+
+func (ws wrappedString) Value() (driver.Value, error) {
+	return string(ws), nil
+}
+
 func TestSQLValue(t *testing.T) {
 	opt1 := options.New(3.14)
 	value1 := toSQLValue(t, opt1)
@@ -208,6 +223,10 @@ func TestSQLValue(t *testing.T) {
 	opt5 := options.None[time.Time]()
 	value5 := toSQLValue(t, opt5)
 	assertEqual[any](t, value5, nil)
+
+	opt6 := options.New[wrappedString]("hello")
+	value6 := toSQLValue(t, opt6)
+	assertEqual[any](t, value6, "hello")
 }
 
 func TestSQLScan(t *testing.T) {
@@ -251,6 +270,12 @@ func TestSQLScan(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertEqual(t, opt6, options.None[string]())
+
+	var opt7 options.Option[wrappedString]
+	if err := opt7.Scan("hello"); err != nil {
+		t.Fatal(err)
+	}
+	assertEqual(t, opt7, options.New[wrappedString]("hello"))
 }
 
 func TestEqual(t *testing.T) {


### PR DESCRIPTION
Currently, `Option[T]` can be used as a `driver.Valuer` when `T` is a `driver.Value` (e.g. int or string).
(Note the difference between `Value` and `Valuer`.)

However, if `T` is wrapped in a struct, `Option[T]` can no longer be used as a `Valuer`, even if the struct implements `driver.Valuer`.

```go
type wrappedString string

// Implements driver.Valuer
func (ws wrappedString) Value() (driver.Value, error) {
	return string(ws), nil
}

// We cannot do this!!
opt := option.New(wrappedString("hello"))
_, err := db.Exec("INSERT INTO `test` VALUES (?)", opt) // ERROR!!
```

This PR solves this problem. If `T` implemets `driver.Valuer`, then `Option[T]` also be a valid Valuer.

## Caveats

Even when `T` is `driver.Valuer`, `*T` is not a `driver.Valuer`. The following code will not work with this PR.

```go
ws := wrappedString("hello")
opt := option.New(&ws) // Option[*wrappedString]
_, err := db.Exec("INSERT INTO `test` VALUES (?)", opt) // ERROR!!
```